### PR TITLE
Fix for the Customization Menu

### DIFF
--- a/source/lua/spe.css
+++ b/source/lua/spe.css
@@ -1,26 +1,22 @@
-css = [[ 
+.shoulder_patches_wrapper
+{
+	top: 82%;
+	left: 80px;
+	width: 300px;
+	height: 14%;
+	vertical-align: top;
+	border-width: 2px;
+	border-color: rgb(0.5, 0.0, 0.0);
+	background-color: rgba(0.2, 0.0, 0.0, 0.5);
+}
 
-	.shoulder_patches_wrapper
-	{
-		top: 82%;
-		left: 80px;
-		width: 300px;
-		height: 14%;
-		vertical-align: top;
-		border-width: 2px;
-		border-color: rgb(0.5, 0.0, 0.0);
-		background-color: rgba(0.2, 0.0, 0.0, 0.5);
-	}
-	
-	font.shoulder_patches_label
-	{ 
-		text-color: rgb(0.9, 0.75, 0.75); 
-		opacity: 0;
-		font-name: fonts/AgencyFB_small.fnt; 
-		width: 100%;
-		text-align: center; 
-		left: 154px;
-		hover-background-color: rgba(0.5,0.5,0.5,0.4); 
-	} 
-
-]]
+font.shoulder_patches_label
+{
+	text-color: rgb(0.9, 0.75, 0.75);
+	opacity: 0;
+	font-name: fonts/AgencyFB_small.fnt;
+	width: 100%;
+	text-align: center;
+	left: 154px;
+	hover-background-color: rgba(0.5,0.5,0.5,0.4);
+}

--- a/source/lua/spe_CustomizePatches.lua
+++ b/source/lua/spe_CustomizePatches.lua
@@ -4,7 +4,7 @@
 ]]
 Script.Load("lua/spe_ShoulderPatchesConfig.lua")
 Script.Load("lua/spe_ShoulderPatchesMessage.lua")
-    
+
 local speMenuOptions = {
     name  = "ShoulderPatch",
     label = "Custom Patches",
@@ -32,28 +32,28 @@ function GUIMainMenu:CreateCustomizeWindow()
 
     LoadCSSFile("lua/spe.css")
 
-    // create container
+    -- create container
     self.spe = CreateMenuElement(self.mainWindow, "ContentBox", true)
     self.spe:SetCSSClass("shoulder_patches_wrapper")
-    
+
     self.customizeFrame:AddEventCallbacks({
         OnHide = function(self)
             self.scriptHandle.spe:SetIsVisible(false)
         end
     })
-    
-    // create from
-    local form = CreateMenuElement(self.spe, "Form", true)    
+
+    -- create from
+    local form = CreateMenuElement(self.spe, "Form", true)
     form:SetCSSClass("options")
 
-    // label on top of input
+    -- label on top of input
     local label = CreateMenuElement(form, "Font", false)
     label:SetCSSClass("shoulder_patches_label")
     label:SetText(speMenuOptions.label)
     label:SetTopOffset(0)
     label:SetIgnoreEvents(false)
 
-    // input for patches
+    -- input for patches
     local input = form:CreateFormElement(Form.kElementType.DropDown, speMenuOptions.name, patchName)
     input:SetOptions(patchNames)
     input:SetCSSClass(speMenuOptions.css)
@@ -79,6 +79,6 @@ function GUIMainMenu:CreateCustomizeWindow()
     for index, child in ipairs(input:GetChildren()) do
         child:AddEventCallbacks({ OnMouseIn = OnMouseInFn })
     end
-        
+
     self.customizeElements[speMenuOptions.name] = input
 end

--- a/source/lua/spe_shoulderPatchesEnum.lua
+++ b/source/lua/spe_shoulderPatchesEnum.lua
@@ -7,17 +7,17 @@ kEmptyPatchIndex = 0
 kEmptyPatchName = "None"
 
 kShoulderPatchNames = {
-    // "None" - Empty patch with index 0 (reserved)
-    "Approved", // Wooza approved patch
-    "ZycaR",    // ZycaR (reserved)
-    "Nalice",   // Nalice (reserved)
+    -- "None" - Empty patch with index 0 (reserved)
+    "Approved", -- Wooza approved patch
+    "ZycaR",    -- ZycaR (reserved)
+    "Nalice",   -- Nalice (reserved)
     "Lerk",
     "Dilligaf",
     "karrot",
     "wooza1",
     "Redguy",
     "Avenger",
-    "O.R.A. Playtest",  // Wooza's O.R.A Play-testing Event
+    "O.R.A. Playtest",  -- Wooza's O.R.A Play-testing Event
     "Pacific",
     "Gretel",
     "Yolo",


### PR DESCRIPTION
Since Build 314, NS2 has a bug in the CSS parser when feeding it old-style css files. This breaks the customization menu. This patch fixes that until NS2 fixes implements the bugfix on their end.